### PR TITLE
Add pre-populated db

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,7 @@ services:
  # Deployment of multiple instances may harm the system performance.
             
     oss-db: # data storage service
-        image: mongo:3.4 #current setup uses mongodb
+        build: ./oss-db
         networks:
             - default
         expose:  #exposes database port to oss-web and oss-app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,8 @@
 version: "3"
 services: 
     oss-web: # Deploys the OSSMETER Web App
-        build: ./oss-web  # Directory to the corresponding Dockerfile 
+        image: crossminer/ossmeter-web
+#        build: ./oss-web  # Directory to the corresponding Dockerfile 
         depends_on: 
             - oss-app
             - oss-db # Only requests for oss-db service to be launched before this service. 
@@ -38,7 +39,8 @@ services:
    
     oss-app: # Deploys a container with the OSSMETER platform configured to act as master
              # and to run the api server used by oss-web service
-        build: ./oss-platform
+        image: crossminer/ossmeter-platform
+#        build: ./oss-platform
         entrypoint: ./eclipse -apiServer -master -ossmeterConfig prop.properties
         depends_on:
             - oss-db
@@ -49,7 +51,8 @@ services:
             - 8183 # Admin API?
             
     oss-slave: # Service containing OSSMETER slaves instances.
-        build: ./oss-platform
+        image: crossminer/ossmeter-platform
+#        build: ./oss-platform
         entrypoint: ./eclipse -slave -ossmeterConfig prop.properties
         depends_on:
             - oss-db
@@ -65,7 +68,8 @@ services:
  # Deployment of multiple instances may harm the system performance.
             
     oss-db: # data storage service
-        build: ./oss-db
+        image: crossminer/ossmeter-db
+#        build: ./oss-db
         networks:
             - default
         expose:  #exposes database port to oss-web and oss-app

--- a/oss-db/Dockerfile
+++ b/oss-db/Dockerfile
@@ -1,0 +1,11 @@
+FROM mongo:3.4
+
+ADD http://ci3.castalia.camp/dl/ossmeter_dump_full.tar.gz /home/
+WORKDIR /home/
+RUN tar xzf ossmeter_dump_full.tar.gz
+COPY mongo-restore.sh /home/mongo-restore.sh
+RUN chmod 777 /home/mongo-restore.sh
+
+RUN /home/mongo-restore.sh
+
+CMD ["mongod"]

--- a/oss-db/mongo-restore.sh
+++ b/oss-db/mongo-restore.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Initialize a mongo data folder and logfile
+mkdir -p /data/db
+touch /var/log/mongodb.log
+chmod 777 /var/log/mongodb.log
+
+# Start mongodb with logging
+# --logpath    Without this mongod will output all log information to the standard output.
+# --logappend  Ensure mongod appends new entries to the end of the logfile. We create it first so that the below tail always finds something
+/entrypoint.sh mongod --logpath /var/log/mongodb.log --logappend &
+
+# Wait until mongo logs that it's ready (or timeout after 60s)
+COUNTER=0
+grep -q 'waiting for connections on port' /var/log/mongodb.log
+while [[ $? -ne 0 && $COUNTER -lt 60 ]] ; do
+    sleep 2
+    let COUNTER+=2
+    echo "Waiting for mongo to initialize... ($COUNTER seconds so far)"
+    grep -q 'waiting for connections on port' /var/log/mongodb.log
+done
+
+# Restore from dump
+
+mongorestore --drop --db ossmeter /home/dump/ossmeter
+mongorestore --drop --db pongo /home/dump/pongo
+mongorestore --drop --db users /home/dump/users
+
+# Keep container running
+#tail -f /dev/null
+


### PR DESCRIPTION
Hum.. The resulting compose works well on my host, but on the ci service the user is still not found.. Some extended tests (i.e. simply composing up) in a different context/from a different person with different habits may help.. 
The ci service actually uses a different composing system, and I believe the bugging point is there, so the actual docker-compose file works well. Any more help/testing would be good.